### PR TITLE
Fix reference leak

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -13,7 +13,7 @@ class Mark1DemoSkill(MycroftSkill):
         self.thread = None
 
     def initialize(self):
-        self.emitter.on("mycroft.mark1.demo", self.demo)
+        self.add_event("mycroft.mark1.demo", self.demo, False)
 
     def animate(self, t, often, func, *args):
         t = time.time() + t


### PR DESCRIPTION
====  Tech Notes ====
The handler for `mycroft.mark1.demo` wasn't removed at shutdown. Now
it's registered using `self.add_event()` to make sure it's cleaned up
during shutdown.